### PR TITLE
Move hardcoded secrets out of code into configuration

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build --configuration Release
+        env:
+          Emt__PassKey: ${{ secrets.EMT_PASSKEY }}
+          Emt__ClientId: ${{ secrets.EMT_CLIENTID }}
+          ElCano__AccessKey: ${{ secrets.ELCANO_ACCESSKEY }}
+          ElCano__SecretKey: ${{ secrets.ELCANO_SECRETKEY }}
+          ElCano__UserId: ${{ secrets.ELCANO_USERID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,24 @@ Tests are integration tests that use `PostgresFixture` (Testcontainers + `postgr
 
 ### Configuration
 
-- `appsettings.json` — PostgreSQL connection string, CRTM endpoint/timeout, EMT credentials
-- `appsettings.Development.json` — logging overrides
+- `appsettings.json` — PostgreSQL connection string, CRTM endpoint/timeout, plus **empty placeholders** for the `Emt` (`PassKey`, `ClientId`) and `ElCano` (`AccessKey`, `SecretKey`, `UserId`, `Client`) secret sections
 - Local dev DB: `Host=localhost;Database=madrid_transporte;Username=app;Password=secret` (matches `docker-compose.yml`)
+
+#### Secrets
+
+Real values for the `Emt` and `ElCano` sections are **not committed**. Supply them via:
+
+- **Local dev:** .NET user-secrets (auto-loaded in the `Development` environment). The API project has a `UserSecretsId`. Set values with, e.g.:
+  ```bash
+  dotnet user-secrets set "Emt:PassKey" "<value>" --project MadridTransporte.Api
+  dotnet user-secrets set "Emt:ClientId" "<value>" --project MadridTransporte.Api
+  dotnet user-secrets set "ElCano:AccessKey" "<value>" --project MadridTransporte.Api
+  dotnet user-secrets set "ElCano:SecretKey" "<value>" --project MadridTransporte.Api
+  dotnet user-secrets set "ElCano:UserId" "<value>" --project MadridTransporte.Api
+  ```
+- **Production/CI:** environment variables (double-underscore separator), e.g. `Emt__PassKey`, `Emt__ClientId`, `ElCano__AccessKey`, `ElCano__SecretKey`, `ElCano__UserId`.
+
+`EmtClient` and `ElCanoAuthHandler` read these via `IConfiguration` and throw `InvalidOperationException` at runtime if a required key is missing/empty (`IConfiguration.GetRequired` in `Utils/ConfigurationExtensions.cs`).
 
 ### Deployment
 

--- a/MadridTransporte.Api/Clients/Emt/EmtClient.cs
+++ b/MadridTransporte.Api/Clients/Emt/EmtClient.cs
@@ -6,7 +6,12 @@ using MadridTransporte.Api.Utils;
 
 namespace MadridTransporte.Api.Clients.Emt;
 
-public class EmtClient(HttpClient httpClient, StopsService stopsService, ILogger<EmtClient> logger)
+public class EmtClient(
+    HttpClient httpClient,
+    StopsService stopsService,
+    IConfiguration config,
+    ILogger<EmtClient> logger
+)
 {
     private string? _accessToken;
     private readonly SemaphoreSlim _loginLock = new(1, 1);
@@ -20,13 +25,10 @@ public class EmtClient(HttpClient httpClient, StopsService stopsService, ILogger
                 HttpMethod.Get,
                 "https://openapi.emtmadrid.es/v1/mobilitylabs/user/login/"
             );
-            request.Headers.TryAddWithoutValidation(
-                "passKey",
-                "504fea88211f2f90633f964189b7696037d65cc3a5f47b8fa1d5ea5e34db0239ad2e068851e72be0cec125779224749e3bc236c1b7af39d8a3d398e99223f058"
-            );
+            request.Headers.TryAddWithoutValidation("passKey", config.GetRequired("Emt:PassKey"));
             request.Headers.TryAddWithoutValidation(
                 "X-ClientId",
-                "428B01E6-693C-4F7F-A11E-3BB923420587"
+                config.GetRequired("Emt:ClientId")
             );
 
             var response = await httpClient.SendAsync(request, ct);

--- a/MadridTransporte.Api/Clients/Train/ElCanoAuthHandler.cs
+++ b/MadridTransporte.Api/Clients/Train/ElCanoAuthHandler.cs
@@ -1,10 +1,13 @@
+using MadridTransporte.Api.Utils;
+
 namespace MadridTransporte.Api.Clients.Train;
 
-public class ElCanoAuthHandler : DelegatingHandler
+public class ElCanoAuthHandler(IConfiguration config) : DelegatingHandler
 {
-    private const string AccessKey = "and20210615";
-    private const string SecretKey = "Jthjtr946RTt";
-    private const string UserId = "718da3df4199ede4";
+    private string AccessKey => config.GetRequired("ElCano:AccessKey");
+    private string SecretKey => config.GetRequired("ElCano:SecretKey");
+    private string UserId => config.GetRequired("ElCano:UserId");
+    private string Client => config["ElCano:Client"] is { Length: > 0 } c ? c : "AndroidElcanoApp";
 
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
@@ -23,7 +26,7 @@ public class ElCanoAuthHandler : DelegatingHandler
             path: uri.AbsolutePath,
             httpMethod: request.Method.Method,
             contentType: "application/json;charset=utf-8",
-            xElcanoClient: "AndroidElcanoApp",
+            xElcanoClient: Client,
             xElcanoUserId: UserId,
             payload: payload,
             queryParams: uri.Query.TrimStart('?')

--- a/MadridTransporte.Api/MadridTransporte.Api.csproj
+++ b/MadridTransporte.Api/MadridTransporte.Api.csproj
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>893d11f1-bfc0-415d-81bc-bb2845bbbe61</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CSharpier.MsBuild" Version="1.2.6">

--- a/MadridTransporte.Api/Utils/ConfigurationExtensions.cs
+++ b/MadridTransporte.Api/Utils/ConfigurationExtensions.cs
@@ -1,0 +1,9 @@
+namespace MadridTransporte.Api.Utils;
+
+public static class ConfigurationExtensions
+{
+    public static string GetRequired(this IConfiguration config, string key) =>
+        config[key] is { Length: > 0 } value
+            ? value
+            : throw new InvalidOperationException($"Missing {key} configuration");
+}

--- a/MadridTransporte.Api/appsettings.Development.json
+++ b/MadridTransporte.Api/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Information",
-    }
-  }
-}

--- a/MadridTransporte.Api/appsettings.json
+++ b/MadridTransporte.Api/appsettings.json
@@ -13,4 +13,14 @@
     "Endpoint": "http://www.citram.es:8080/WSMultimodalInformation/MultimodalInformation.svc",
     "TimeoutSeconds": 30
   },
+  "Emt": {
+    "PassKey": "",
+    "ClientId": ""
+  },
+  "ElCano": {
+    "AccessKey": "",
+    "SecretKey": "",
+    "UserId": "",
+    "Client": "AndroidElcanoApp"
+  }
 }


### PR DESCRIPTION
- Read EMT (PassKey, ClientId) and ElCano (AccessKey, SecretKey, UserId) credentials from IConfiguration instead of hardcoded constants
- Add IConfiguration.GetRequired extension that fails loudly on missing keys
- appsettings.json holds empty placeholders only; real values come from user-secrets (dev) or environment variables (prod/CI)
- Remove unneeded appsettings.Development.json (logging-only override)
- Document secrets setup in CLAUDE.md