### PR TITLE
Move hardcoded Adif User-Key to configuration

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,3 +41,4 @@ jobs:
           ElCano__AccessKey: ${{ secrets.ELCANO_ACCESSKEY }}
           ElCano__SecretKey: ${{ secrets.ELCANO_SECRETKEY }}
           ElCano__UserId: ${{ secrets.ELCANO_USERID }}
+          ElCano__UserKey: ${{ secrets.ELCANO_USERKEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Tests are integration tests that use `PostgresFixture` (Testcontainers + `postgr
 
 ### Configuration
 
-- `appsettings.json` — PostgreSQL connection string, CRTM endpoint/timeout, plus **empty placeholders** for the `Emt` (`PassKey`, `ClientId`) and `ElCano` (`AccessKey`, `SecretKey`, `UserId`, `Client`) secret sections
+- `appsettings.json` — PostgreSQL connection string, CRTM endpoint/timeout, plus **empty placeholders** for the `Emt` (`PassKey`, `ClientId`) and `ElCano` (`AccessKey`, `SecretKey`, `UserId`, `UserKey`, `Client`) secret sections
 - Local dev DB: `Host=localhost;Database=madrid_transporte;Username=app;Password=secret` (matches `docker-compose.yml`)
 
 #### Secrets
@@ -75,8 +75,9 @@ Real values for the `Emt` and `ElCano` sections are **not committed**. Supply th
   dotnet user-secrets set "ElCano:AccessKey" "<value>" --project MadridTransporte.Api
   dotnet user-secrets set "ElCano:SecretKey" "<value>" --project MadridTransporte.Api
   dotnet user-secrets set "ElCano:UserId" "<value>" --project MadridTransporte.Api
+  dotnet user-secrets set "ElCano:UserKey" "<value>" --project MadridTransporte.Api
   ```
-- **Production/CI:** environment variables (double-underscore separator), e.g. `Emt__PassKey`, `Emt__ClientId`, `ElCano__AccessKey`, `ElCano__SecretKey`, `ElCano__UserId`.
+- **Production/CI:** environment variables (double-underscore separator), e.g. `Emt__PassKey`, `Emt__ClientId`, `ElCano__AccessKey`, `ElCano__SecretKey`, `ElCano__UserId`, `ElCano__UserKey`.
 
 `EmtClient` and `ElCanoAuthHandler` read these via `IConfiguration` and throw `InvalidOperationException` at runtime if a required key is missing/empty (`IConfiguration.GetRequired` in `Utils/ConfigurationExtensions.cs`).
 

--- a/MadridTransporte.Api/Clients/Train/TrainClient.cs
+++ b/MadridTransporte.Api/Clients/Train/TrainClient.cs
@@ -11,6 +11,7 @@ public class TrainClient(
     IHttpClientFactory httpClientFactory,
     StopsService stopsService,
     BusClient crtmFallback,
+    IConfiguration config,
     ILogger<TrainClient> logger
 )
 {
@@ -74,7 +75,10 @@ public class TrainClient(
             {
                 Content = content,
             };
-            request.Headers.TryAddWithoutValidation("User-Key", "f4ce9fbfa9d721e39b8984805901b5df");
+            request.Headers.TryAddWithoutValidation(
+                "User-Key",
+                config.GetRequired("ElCano:UserKey")
+            );
             request.Headers.TryAddWithoutValidation("Host", "circulacion.api.adif.es");
             request.Headers.TryAddWithoutValidation("User-Agent", "okhttp/4.10.0");
             request.Headers.TryAddWithoutValidation("Connection", "Close");

--- a/MadridTransporte.Api/appsettings.json
+++ b/MadridTransporte.Api/appsettings.json
@@ -21,6 +21,7 @@
     "AccessKey": "",
     "SecretKey": "",
     "UserId": "",
+    "UserKey": "",
     "Client": "AndroidElcanoApp"
   }
 }


### PR DESCRIPTION
The Adif User-Key was hardcoded in TrainClient. Read it from configuration (ElCano:UserKey) instead, matching how the other Emt/ElCano secrets are handled: user-secrets locally and the ElCano__UserKey env var in CI.