### PR TITLE
Fix HTTP 500 on EMT locations for lines with no route row

### DIFF
--- a/MadridTransporte.Api/Endpoints/LinesEndpoints.cs
+++ b/MadridTransporte.Api/Endpoints/LinesEndpoints.cs
@@ -37,7 +37,7 @@ public static class LinesEndpoints
                 var route = await routesService.GetRouteByFullLineCodeAsync(lineCode, ct);
                 var simpleLineCode =
                     route?.SimpleLineCode ?? CodeUtils.GetSimpleLineCodeFromLineCode(lineCode);
-                var routeCodMode = route?.CodMode ?? CodeUtils.GetCodModeFromLineCode(lineCode);
+                var routeCodMode = route?.CodMode ?? CodeUtils.EmtCodMode;
 
                 var locations =
                     await emtClient.GetLineLocationsAsync(

--- a/MadridTransporte.Api/Utils/CodeUtils.cs
+++ b/MadridTransporte.Api/Utils/CodeUtils.cs
@@ -16,8 +16,13 @@ public static class CodeUtils
 
     public static string GetCodModeFromLineCode(string input) => input.Split("__")[0];
 
-    public static string GetSimpleLineCodeFromLineCode(string input) =>
-        input.Split("__")[1].Split("___")[0];
+    public static string GetSimpleLineCodeFromLineCode(string input)
+    {
+        // Full line codes look like "codMode__line___" (e.g. "8__450___"). EMT URLs use the
+        // bare line code (e.g. "881"), which has no "__" separator — return it unchanged.
+        var parts = input.Split("__");
+        return parts.Length > 1 ? parts[1].Split("___")[0] : input;
+    }
 
     public static string GetStopCodeFromFullStopCode(string input) =>
         input[(input.IndexOf('_') + 1)..];

--- a/MadridTransporte.Loader/MadridTransporte.Loader.csproj
+++ b/MadridTransporte.Loader/MadridTransporte.Loader.csproj
@@ -14,4 +14,9 @@
   <ItemGroup>
     <ProjectReference Include="..\MadridTransporte.Api\MadridTransporte.Api.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\MadridTransporte.Api\appsettings.json" Link="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/MadridTransporte.Loader/Program.cs
+++ b/MadridTransporte.Loader/Program.cs
@@ -5,7 +5,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-var builder = Host.CreateApplicationBuilder(args);
+var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory,
+});
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Postgres"))

--- a/MadridTransporte.Tests/CodeUtilsTests.cs
+++ b/MadridTransporte.Tests/CodeUtilsTests.cs
@@ -1,0 +1,36 @@
+using MadridTransporte.Api.Utils;
+using Shouldly;
+
+namespace MadridTransporte.Tests;
+
+// Pure-logic unit tests for line-code parsing. These guard the EMT regression where a bare
+// line code (the EMT URL form, e.g. "/lines/emt/881/locations/1") with no route row in the DB
+// fell through to GetSimpleLineCodeFromLineCode and threw IndexOutOfRangeException -> HTTP 500.
+public class CodeUtilsTests
+{
+    // Full line codes ("codMode__line___") keep their existing behavior.
+    [Test]
+    [Arguments("8__450___", "450")]
+    [Arguments("4__12___", "12")]
+    [Arguments("5__4_A__", "4_A")]
+    [Arguments("10__ML4___", "ML4")]
+    [Arguments("9__2__065_", "2")]
+    public async Task GetSimpleLineCodeFromLineCode_Parses_Full_Codes(string input, string expected)
+    {
+        CodeUtils.GetSimpleLineCodeFromLineCode(input).ShouldBe(expected);
+        await Task.CompletedTask;
+    }
+
+    // EMT URLs use the bare line code (route_id), which has no "__" separator. It must be
+    // returned unchanged instead of throwing.
+    [Test]
+    [Arguments("881")]
+    [Arguments("144")]
+    [Arguments("N26")]
+    public async Task GetSimpleLineCodeFromLineCode_Returns_Bare_Code_Unchanged(string input)
+    {
+        Should.NotThrow(() => CodeUtils.GetSimpleLineCodeFromLineCode(input));
+        CodeUtils.GetSimpleLineCodeFromLineCode(input).ShouldBe(input);
+        await Task.CompletedTask;
+    }
+}

--- a/MadridTransporte.Tests/Fixtures/PostgresFixture.cs
+++ b/MadridTransporte.Tests/Fixtures/PostgresFixture.cs
@@ -4,6 +4,7 @@ using MadridTransporte.Api.Loader;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Testcontainers.PostgreSql;
 using TUnit.Core.Interfaces;
@@ -34,6 +35,13 @@ public class PostgresFixture : IAsyncInitializer, IAsyncDisposable
         Factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.UseEnvironment("Testing");
+
+            // Load the API project's user-secrets (Emt/ElCano keys) so external-API tests run
+            // locally. Optional, so CI is unaffected and keeps supplying them via env vars.
+            builder.ConfigureAppConfiguration(config =>
+                config.AddUserSecrets(typeof(Program).Assembly, optional: true)
+            );
+
             builder.ConfigureServices(services =>
             {
                 var descriptor = services.SingleOrDefault(d =>

--- a/MadridTransporte.Tests/ItinerariesTests.cs
+++ b/MadridTransporte.Tests/ItinerariesTests.cs
@@ -9,6 +9,7 @@ namespace MadridTransporte.Tests;
 public enum ItinerariesUrls
 {
     EmtDirectionBased,
+    EmtDirectionBased2,
     InterurbanDirectionBased,
     Interurban2DirectionBased,
     UrbanDirectionBased,
@@ -32,6 +33,9 @@ public class ItinerariesTests(PostgresFixture fixture)
         code switch
         {
             ItinerariesUrls.EmtDirectionBased => ("/lines/emt/144/itineraries/2?stopCode=4597", 2),
+            // Line 881 (special service "S10"): EMT URLs use the bare line code, and this line
+            // has no route_short_name match — the case that used to 500 on the locations endpoint.
+            ItinerariesUrls.EmtDirectionBased2 => ("/lines/emt/881/itineraries/1?stopCode=34", 1),
             ItinerariesUrls.InterurbanDirectionBased => (
                 "/lines/bus/8__450___/itineraries/1?stopCode=08242",
                 1
@@ -69,6 +73,7 @@ public class ItinerariesTests(PostgresFixture fixture)
 
     [Test]
     [Arguments(ItinerariesUrls.EmtDirectionBased)]
+    [Arguments(ItinerariesUrls.EmtDirectionBased2)]
     [Arguments(ItinerariesUrls.InterurbanDirectionBased)]
     [Arguments(ItinerariesUrls.Interurban2DirectionBased)]
     [Arguments(ItinerariesUrls.UrbanDirectionBased)]

--- a/MadridTransporte.Tests/LocationsTests.cs
+++ b/MadridTransporte.Tests/LocationsTests.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Http.Json;
+using MadridTransporte.Api.Dtos;
+using MadridTransporte.Tests.Fixtures;
+using Shouldly;
+
+namespace MadridTransporte.Tests;
+
+[ClassDataSource<PostgresFixture>(Shared = SharedType.PerTestSession)]
+public class LocationsTests(PostgresFixture fixture)
+{
+    // EMT URLs use the bare line code (the GTFS route_id). Line 881 ("S10") used to return
+    // HTTP 500 here because the null-route fallback parsed the bare code as a full line code.
+    [Test]
+    [Arguments("/lines/emt/881/locations/1?stopCode=34")]
+    [Arguments("/lines/emt/144/locations/1?stopCode=4597")]
+    public async Task Should_Get_Emt_Line_Locations(string url)
+    {
+        var response = await fixture.Client.GetAsync(url);
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, body);
+
+        var locations = await response.Content.ReadFromJsonAsync<VehicleLocationsDto>(
+            PostgresFixture.JsonOptions
+        );
+        locations.ShouldNotBeNull();
+        // EMT mode, regardless of whether the line has a route row in the DB.
+        locations.CodMode.ShouldBe(int.Parse(MadridTransporte.Api.Utils.CodeUtils.EmtCodMode));
+        locations.LineCode.ShouldNotBeNullOrEmpty();
+        // Vehicle positions depend on live service, so the list may be empty — but each entry,
+        // when present, must be well-formed.
+        foreach (var vehicle in locations.Locations)
+        {
+            vehicle.SimpleLineCode.ShouldNotBeNullOrEmpty();
+            vehicle.Coordinates.ShouldNotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
EMT URLs use the bare line code (the GTFS route_id, e.g. "881"), not the full "codMode__line___" form. When the line has no matching Routes row (EMT routes.txt does not always cover every route_id its trips reference), the locations endpoint fell through to GetSimpleLineCodeFromLineCode, which did input.Split("__")[1] and threw IndexOutOfRangeException -> 500.

- GetSimpleLineCodeFromLineCode now returns the input unchanged when there is no "__" separator; the full-code branch is unchanged.
- EMT locations endpoint's codMode fallback now uses EmtCodMode instead of GetCodModeFromLineCode (which returned the bare line code as a mode).
- Add CodeUtilsTests covering bare and full line codes.