### PR TITLE
Move CRTM private key from hardcoded value to configuration

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release
         env:
+          Crtm__PrivateKey: ${{ secrets.CRTM_PRIVATEKEY }}
           Emt__PassKey: ${{ secrets.EMT_PASSKEY }}
           Emt__ClientId: ${{ secrets.EMT_CLIENTID }}
           ElCano__AccessKey: ${{ secrets.ELCANO_ACCESSKEY }}

--- a/MadridTransporte.Api/Clients/Crtm/CrtmAuthHelper.cs
+++ b/MadridTransporte.Api/Clients/Crtm/CrtmAuthHelper.cs
@@ -5,15 +5,12 @@ namespace MadridTransporte.Api.Clients.Crtm;
 
 public static class CrtmAuthHelper
 {
-    private static readonly byte[] PrivateKey = Encoding.UTF8.GetBytes(
-        "pruebapruebapruebapruebaprueba12"
-    );
     private static readonly byte[] Iv = new byte[16];
 
-    public static string Encrypt(byte[] publicKey)
+    public static string Encrypt(byte[] publicKey, string privateKey)
     {
         using var aes = Aes.Create();
-        aes.Key = PrivateKey;
+        aes.Key = Encoding.UTF8.GetBytes(privateKey);
         aes.IV = Iv;
         aes.Mode = CipherMode.CBC;
         aes.Padding = PaddingMode.PKCS7;

--- a/MadridTransporte.Api/Clients/Crtm/CrtmClient.cs
+++ b/MadridTransporte.Api/Clients/Crtm/CrtmClient.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using MadridTransporte.Api.Clients.Crtm.Generated;
 using MadridTransporte.Api.Dtos;
+using MadridTransporte.Api.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.ObjectPool;
 using Gen = MadridTransporte.Api.Clients.Crtm.Generated;
@@ -16,13 +17,19 @@ public partial class CrtmClient(
     private readonly ObjectPool<MultimodalInformationClient> _pool =
         new DefaultObjectPool<MultimodalInformationClient>(new ClientPolicy(config));
 
+    private readonly string _privateKey = config.GetRequired("Crtm:PrivateKey");
+
     private static async Task<AuthHeader> GetAuthAsync(
         MultimodalInformationClient client,
+        string privateKey,
         CancellationToken ct
     )
     {
         var response = await client.GetPublicKeyAsync().WaitAsync(ct);
-        var connectionKey = CrtmAuthHelper.Encrypt(Encoding.UTF8.GetBytes(response.key));
+        var connectionKey = CrtmAuthHelper.Encrypt(
+            Encoding.UTF8.GetBytes(response.key),
+            privateKey
+        );
         return new AuthHeader { connectionKey = connectionKey };
     }
 
@@ -34,7 +41,7 @@ public partial class CrtmClient(
         var client = _pool.Get();
         try
         {
-            var auth = await GetAuthAsync(client, ct);
+            var auth = await GetAuthAsync(client, _privateKey, ct);
             var response = await client
                 .GetStopTimesAsync(auth, fullStopCode, 1, 2, null, null, null, 3)
                 .WaitAsync(ct);
@@ -61,7 +68,7 @@ public partial class CrtmClient(
         var client = _pool.Get();
         try
         {
-            var auth = await GetAuthAsync(client, ct);
+            var auth = await GetAuthAsync(client, _privateKey, ct);
             var response = await client
                 .GetIncidentsAffectationsAsync(auth, codMode, [])
                 .WaitAsync(ct);
@@ -92,7 +99,7 @@ public partial class CrtmClient(
         var client = _pool.Get();
         try
         {
-            var auth = await GetAuthAsync(client, ct);
+            var auth = await GetAuthAsync(client, _privateKey, ct);
             var response = await client.GetLineItinerariesAsync(auth, lineCode, 1).WaitAsync(ct);
             return MapItinerariesResponse(response.itineraries, lineCode, direction);
         }
@@ -142,7 +149,7 @@ public partial class CrtmClient(
         var client = _pool.Get();
         try
         {
-            var auth = await GetAuthAsync(client, ct);
+            var auth = await GetAuthAsync(client, _privateKey, ct);
             var response = await client
                 .GetLineLocationAsync(
                     auth,

--- a/MadridTransporte.Api/appsettings.json
+++ b/MadridTransporte.Api/appsettings.json
@@ -11,7 +11,8 @@
   },
   "Crtm": {
     "Endpoint": "http://www.citram.es:8080/WSMultimodalInformation/MultimodalInformation.svc",
-    "TimeoutSeconds": 30
+    "TimeoutSeconds": 30,
+    "PrivateKey": ""
   },
   "Emt": {
     "PassKey": "",

--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,8 @@ services:
     environment:
       - ConnectionStrings__Postgres=Host=db;Database=madrid_transporte;Username=app;Password=secret
       - Crtm__TimeoutSeconds=45
-      # Secrets — required for live EMT / Renfe (Adif) data
+      # Secrets — required for live CRTM / EMT / Renfe (Adif) data
+      - Crtm__PrivateKey=${CRTM_PRIVATEKEY}
       - Emt__PassKey=${EMT_PASSKEY}
       - Emt__ClientId=${EMT_CLIENTID}
       - ElCano__AccessKey=${ELCANO_ACCESSKEY}
@@ -80,6 +81,7 @@ The API is configured via environment variables (using the standard ASP.NET Core
 | `ConnectionStrings__Postgres` | Yes | PostgreSQL connection string. Used by both the API and the loader. |
 | `Crtm__TimeoutSeconds` | No | Timeout (seconds) for the CRTM SOAP client. Defaults to `30`. |
 | `Crtm__Endpoint` | No | CRTM SOAP endpoint. Defaults to the public CITRAM endpoint. |
+| `Crtm__PrivateKey` | Yes* | CRTM AES private key used to encrypt the connection key (must be 16, 24 or 32 bytes). |
 | `Emt__PassKey` | Yes* | EMT Mobility Labs API pass key. |
 | `Emt__ClientId` | Yes* | EMT Mobility Labs API client id. |
 | `ElCano__AccessKey` | Yes* | Adif (El Cano) API access key. |
@@ -88,11 +90,11 @@ The API is configured via environment variables (using the standard ASP.NET Core
 | `ElCano__UserKey` | Yes* | Adif (El Cano) API user key (the `User-Key` header). |
 | `ElCano__Client` | No | Adif (El Cano) client identifier. Defaults to `AndroidElcanoApp`. |
 
-\* The API starts without these, but the corresponding endpoints (EMT arrivals/locations, Renfe/Adif train times) throw at runtime until the values are supplied. The loader needs only the connection string.
+\* The API starts without these, but the corresponding endpoints (CRTM bus/metro/tram stop times, locations and itineraries; EMT arrivals/locations; Renfe/Adif train times) throw at runtime until the values are supplied. The loader needs only the connection string.
 
 ### Secrets in CI
 
-CI reads the secret values from GitHub Actions secrets (`EMT_PASSKEY`, `EMT_CLIENTID`, `ELCANO_ACCESSKEY`, `ELCANO_SECRETKEY`, `ELCANO_USERID`, `ELCANO_USERKEY`) and maps them onto the matching `__` environment variables.
+CI reads the secret values from GitHub Actions secrets (`CRTM_PRIVATEKEY`, `EMT_PASSKEY`, `EMT_CLIENTID`, `ELCANO_ACCESSKEY`, `ELCANO_SECRETKEY`, `ELCANO_USERID`, `ELCANO_USERKEY`) and maps them onto the matching `__` environment variables.
 
 ## Development
 
@@ -119,9 +121,10 @@ dotnet test --configuration Release
 
 ### Secrets (local)
 
-The EMT and Adif (El Cano) secrets are not committed. In the `Development` environment they are loaded from .NET user-secrets:
+The CRTM, EMT and Adif (El Cano) secrets are not committed. In the `Development` environment they are loaded from .NET user-secrets:
 
 ```bash
+dotnet user-secrets set "Crtm:PrivateKey" "<value>" --project MadridTransporte.Api
 dotnet user-secrets set "Emt:PassKey" "<value>" --project MadridTransporte.Api
 dotnet user-secrets set "Emt:ClientId" "<value>" --project MadridTransporte.Api
 dotnet user-secrets set "ElCano:AccessKey" "<value>" --project MadridTransporte.Api


### PR DESCRIPTION
Read the CRTM AES private key from Crtm:PrivateKey config (required) instead of hardcoding it in CrtmAuthHelper. Add empty placeholder in appsettings.json, wire Crtm__PrivateKey into the CI test step, and document it in the README.