### PR TITLE
Fix Docker restore failure with Central Package Management

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+COPY Directory.Packages.props global.json ./
 COPY MadridTransporte.Api/MadridTransporte.Api.csproj MadridTransporte.Api/
 RUN dotnet restore MadridTransporte.Api/MadridTransporte.Api.csproj
 COPY MadridTransporte.Api/ MadridTransporte.Api/

--- a/Dockerfile-loader
+++ b/Dockerfile-loader
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+COPY Directory.Packages.props global.json ./
 COPY MadridTransporte.Api/MadridTransporte.Api.csproj MadridTransporte.Api/
 COPY MadridTransporte.Loader/MadridTransporte.Loader.csproj MadridTransporte.Loader/
 RUN dotnet restore MadridTransporte.Loader/MadridTransporte.Loader.csproj


### PR DESCRIPTION
Copy Directory.Packages.props and global.json into the build context before dotnet restore. Without them, PackageReference items have no version (versions live in Directory.Packages.props) and restore fails with NU1015.