### PR TITLE
Fix Docker publish failure from excluded appsettings.json

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,5 @@
 **/values.dev.yaml
 **/appsettings.Development.json
 **/appsettings.Production.json
-**/appsettings.json
 LICENSE
 README.md


### PR DESCRIPTION
.dockerignore excluded **/appsettings.json, keeping it out of the build context. The Web SDK auto-includes appsettings.json as content to copy to the publish output, so building the Api project (directly or via the Loader's project reference) failed with MSB3030. The committed file holds only empty secret placeholders, so it is safe to ship; the secret-bearing Development/Production variants stay excluded.